### PR TITLE
feat: default to hosted transcript repo

### DIFF
--- a/Mon-Hans.html
+++ b/Mon-Hans.html
@@ -76,12 +76,18 @@
         </div>
         <div class="row">
           <div>
-            <label for="interval">Polling interval (minutes)</label>
-            <input id="interval" type="number" min="1" step="1" value="15" />
+            <label for="repo">GitHub repo (owner/name)</label>
+            <input id="repo" type="text" placeholder="williammanning68/Mon-Hans" />
           </div>
           <div>
-            <label for="proxy">Optional proxy (to bypass CORS)</label>
-            <input id="proxy" type="url" placeholder="http://localhost:8787/fetch?url=" />
+            <label for="folder">Folder with transcripts</label>
+            <input id="folder" type="text" placeholder="Transcripts" />
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <label for="interval">Polling interval (minutes)</label>
+            <input id="interval" type="number" min="1" step="1" value="15" />
           </div>
         </div>
         <div class="actions">
@@ -90,21 +96,6 @@
           <button class="btn-ghost" id="clearSeen">Clear seen</button>
           <button class="btn-ghost" id="save">Save settings</button>
         </div>
-        <details>
-          <summary>“Why the proxy?”</summary>
-          Some government sites don’t allow cross‑origin requests from a local file. If results don’t load, run a tiny local proxy and put its URL above. Example (copy into a terminal as <code>proxy.mjs</code>):
-          <pre><code>import http from 'node:http';
-import https from 'node:https';
-import { URL } from 'node:url';
-http.createServer((req, res) => {
-  const u = new URL(req.url, 'http://localhost');
-  const target = u.searchParams.get('url');
-  if (!target) { res.writeHead(400); return res.end('Missing url'); }
-  const lib = target.startsWith('https') ? https : http;
-  lib.get(target, (r) => {res.writeHead(200, {'content-type': r.headers['content-type']||'text/html'}); r.pipe(res);}).on('error', e => {res.writeHead(500);res.end(String(e));});
-}).listen(8787);
-console.log('Proxy on http://localhost:8787/fetch?url=');</code></pre>
-        </details>
       </section>
 
       <section class="panel">
@@ -121,24 +112,19 @@ console.log('Proxy on http://localhost:8787/fetch?url=');</code></pre>
       </section>
     </div>
 
-    <div class="footer">
-      <div>Data source: Parliament of Tasmania Hansard search</div>
-      <div id="lastRun">—</div>
+      <div class="footer">
+        <div>Data source: GitHub transcript cache</div>
+        <div id="lastRun">—</div>
+      </div>
     </div>
-  </div>
 
 <script>
 // ========================
 // Tas Hansard Watch (client-only)
 // ========================
-// This single-file page polls the Tasmanian Parliament Hansard search for your queries and flags new/updated matches.
-// It uses the public search pages like:
-//   https://search.parliament.tas.gov.au/adv/hahansard (House of Assembly)
-//   https://search.parliament.tas.gov.au/adv/lchansard (Legislative Council)
-// and result pages such as:
-//   https://search.parliament.tas.gov.au/search/search/search?IW_DATABASE=Hansard&IW_FIELD_ADVANCE_PHRASE=...&IW_SORT=-9
-// If your browser blocks cross-origin fetches, set an HTTP proxy above and the app will prepend it to requests.
-
+// This single-file page checks a GitHub repository containing downloaded Hansard transcripts
+// and highlights occurrences of your keywords. Point the page at any repo/folder that holds
+// UTF-8 Hansard .txt files and it will poll for updates.
 const $ = (sel)=>document.querySelector(sel);
 const $$ = (sel)=>Array.from(document.querySelectorAll(sel));
 const state = {
@@ -153,7 +139,8 @@ const DEFAULTS = {
   interval: 15,
   house: 'both',
   keywords: ['"cost of living"','housing','energy','budget'].join('\n'),
-  proxy: ''
+  repo: 'williammanning68/Mon-Hans',
+  folder: 'Transcripts'
 };
 
 function saveSettings(){
@@ -161,14 +148,16 @@ function saveSettings(){
   localStorage.setItem('tashansard.years',$('#years').value.trim());
   localStorage.setItem('tashansard.interval',$('#interval').value.trim());
   localStorage.setItem('tashansard.house',$('#house').value);
-  localStorage.setItem('tashansard.proxy',$('#proxy').value.trim());
+  localStorage.setItem('tashansard.repo',$('#repo').value.trim());
+  localStorage.setItem('tashansard.folder',$('#folder').value.trim());
 }
 function loadSettings(){
   $('#keywords').value = localStorage.getItem('tashansard.keywords') || DEFAULTS.keywords;
   $('#years').value    = localStorage.getItem('tashansard.years')    || DEFAULTS.years;
   $('#interval').value = localStorage.getItem('tashansard.interval') || DEFAULTS.interval;
   $('#house').value    = localStorage.getItem('tashansard.house')    || DEFAULTS.house;
-  $('#proxy').value    = localStorage.getItem('tashansard.proxy')    || DEFAULTS.proxy;
+  $('#repo').value     = localStorage.getItem('tashansard.repo')     || DEFAULTS.repo;
+  $('#folder').value   = localStorage.getItem('tashansard.folder')   || DEFAULTS.folder;
 }
 
 function nowStr(){
@@ -191,103 +180,63 @@ async function runOnce(){
   const kws = $('#keywords').value.split(/\n+/).map(s=>s.trim()).filter(Boolean);
   const years = $('#years').value.split(',').map(s=>s.trim()).filter(Boolean);
   const house = $('#house').value; // both | ha | lc
-  const proxy = $('#proxy').value.trim();
+  const repo = $('#repo').value.trim();
+  const folder = $('#folder').value.trim();
 
   $('#status').textContent = 'Checking…';
   $('#lastRun').textContent = `Last run: ${nowStr()}`;
-  $('#live').textContent = 'Fetching search results…';
+  $('#live').textContent = 'Fetching transcripts…';
 
   const tbody = $('#tbody');
   tbody.innerHTML = '';
 
-  // Build a set of search URLs
-  const urls = [];
-  for (const kw of kws){
-    const param = buildQueryParam(kw);
-    for (const y of (years.length?years:[new Date().getFullYear().toString()])){
-      // Base search across Hansard (both houses)
-      let base = `https://search.parliament.tas.gov.au/search/search/search?IW_DATABASE=Hansard&IW_SORT=-9&${param}`;
-      // Prefer to bias by year via a phrase include (year in doc body title). If nothing returns, the site shows older too, but we'll post-filter.
-      if (y) base += `&IW_FIELD_ADVANCE_YEAR=${encodeURIComponent(y)}`; // not guaranteed; we filter on parse too
-      // House-specific advanced pages have their own forms; the underlying DB appears unified. We'll filter by title in parse.
-      urls.push(base);
-    }
+  if (!repo){
+    $('#live').textContent = 'Please provide a GitHub repo in owner/name format.';
+    $('#status').textContent = state.running ? 'Watching…' : 'Idle';
+    return;
   }
 
-  const allItems = [];
-  for (const url of urls){
-    const html = await safeFetch(url, proxy);
-    if (!html) continue;
-    const items = parseSearchResults(html);
-    // Year filter (fallback)
-    const yearSet = new Set(years);
-    const filtered = items.filter(it => years.length ? yearSet.has((it.date||'').slice(-4)) : true);
-    allItems.push(...filtered);
-  }
+  const files = await fetchTranscriptList(repo, folder);
 
-  // Post-filter by house if chosen
-  const houseMap = {ha:'House of Assembly', lc:'Legislative Council'};
-  const post = allItems.filter(it => {
-    if (house === 'both') return true;
-    return (it.house||'').toLowerCase().includes(houseMap[house].toLowerCase());
-  });
-
-  // De-duplicate by URL/title
-  const unique = [];
-  const seenTmp = new Set();
-  for (const it of post){
-    const key = `${it.title}|${it.href}`;
-    if (!seenTmp.has(key)){ seenTmp.add(key); unique.push(it); }
-  }
-
-  // Fetch each detail page to pull “As Text/HTML5” and scan for occurrences
   const rows = [];
-  for (const it of unique){
-    const detailHtml = await safeFetch(it.href, $('#proxy').value.trim());
-    let textUrl = null, html5Url = null;
-    if (detailHtml){
-      const d = new DOMParser().parseFromString(detailHtml, 'text/html');
-      for (const a of d.querySelectorAll('a')){
-        const t = (a.textContent||'').trim().toLowerCase();
-        if (t === 'as text') textUrl = a.href;
-        if (t === 'as html5') html5Url = a.href;
-      }
-    }
-    const bodyUrl = html5Url || textUrl || it.href; // fallback to details page
-    const body = await safeFetch(bodyUrl, $('#proxy').value.trim());
+  for (const f of files){
+    const nameLower = f.name.toLowerCase();
+    if (house !== 'both' && !nameLower.includes(house)) continue;
+    if (years.length && !years.some(y=>nameLower.includes(y))) continue;
+
+    const body = (await safeFetch(f.download_url)).replace(/^\uFEFF/, '');
     const kwHits = scanForKeywords(body, kws);
     if (kwHits.length){
-      const hash = await sha1(bodyUrl + '|' + kwHits.map(h=>h.context).join(''));
+      const hash = await sha1(f.download_url + '|' + kwHits.map(h=>h.context).join(''));
       const isNew = !state.seen.has(hash);
       if (isNew){
         state.seen.add(hash);
         stickySeen();
-        notify('New Hansard match', `${it.house} • ${it.date}\n${it.title}`);
+        notify('New Hansard match', f.name);
       }
-      rows.push(renderRow({ ...it, bodyUrl, kwHits, isNew }));
+      rows.push(renderRow({
+        date: extractDate(f.name),
+        house: guessHouse(f.name),
+        title: f.name,
+        bodyUrl: f.html_url,
+        kwHits,
+        isNew
+      }));
     }
   }
 
   if (!rows.length){
     $('#live').innerHTML = 'No matches found yet for the current settings.';
   } else {
-    $('#live').innerHTML = `${rows.length} match(es). ${unique.length} document(s) checked.`;
+    $('#live').innerHTML = `${rows.length} match(es). ${files.length} document(s) checked.`;
   }
   for (const r of rows){ $('#tbody').insertAdjacentHTML('beforeend', r); }
   $('#status').textContent = state.running ? 'Watching…' : 'Idle';
 }
 
-function buildQueryParam(kw){
-  // If user typed a quoted phrase, prefer IW_FIELD_ADVANCE_PHRASE
-  const hasQuotes = /^".*"$/.test(kw);
-  const field = hasQuotes ? 'IW_FIELD_ADVANCE_PHRASE' : 'IW_FIELD_ADVANCE_ALLWORDS';
-  return `${field}=${encodeURIComponent(kw)}`;
-}
-
-async function safeFetch(url, proxy){
-  const finalUrl = proxy ? `${proxy}${encodeURIComponent(url)}` : url;
+async function safeFetch(url){
   try{
-    const res = await fetch(finalUrl, { credentials:'omit' });
+    const res = await fetch(url, { credentials:'omit' });
     if (!res.ok) throw new Error(res.status + ' ' + res.statusText);
     return await res.text();
   }catch(e){
@@ -296,22 +245,29 @@ async function safeFetch(url, proxy){
   }
 }
 
-function parseSearchResults(html){
-  const doc = new DOMParser().parseFromString(html, 'text/html');
-  // Heuristic: result list contains anchors near a date node and a title.
-  const out = [];
-  doc.querySelectorAll('a').forEach(a => {
-    const txt = (a.textContent||'').trim();
-    if (!txt) return;
-    // Likely result title looks like “House of Assembly Tuesday 4 March 2025”
-    const m = txt.match(/(House of Assembly|Legislative Council).*?(\d{1,2} [A-Za-z]+ \d{4})/i);
-    if (m){
-      const row = a.closest('tr') || a.closest('div') || a.parentElement;
-      let date = m[2];
-      out.push({ title: txt, date, house: m[1], href: a.href });
-    }
-  });
-  return out;
+async function fetchTranscriptList(repo, folder){
+  const api = `https://api.github.com/repos/${repo}/contents/${folder}`;
+  try{
+    const res = await fetch(api, { credentials:'omit' });
+    if (!res.ok) throw new Error(res.status + ' ' + res.statusText);
+    const data = await res.json();
+    return data.filter(f=>f.type==='file' && f.name.endsWith('.txt'));
+  }catch(e){
+    console.warn('List fetch failed', e, api);
+    return [];
+  }
+}
+
+function extractDate(name){
+  const m = name.match(/(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1] : '';
+}
+
+function guessHouse(name){
+  const n = name.toLowerCase();
+  if (n.includes('ha')) return 'House of Assembly';
+  if (n.includes('lc')) return 'Legislative Council';
+  return '';
 }
 
 function scanForKeywords(body, kws){


### PR DESCRIPTION
## Summary
- prefill GitHub repo and transcript folder inputs with hosted cache
- default monitor settings to williammanning68/Mon-Hans/Transcripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a66c3b45e48332abdc48131bd16857