### PR TITLE
Serve manual test page from Flask

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Run a local test server and trigger checks for any date and keyword:
 python scripts/manual_server.py
 ```
 
-Open `manual_test.html` in a browser, choose a date and keyword, and submit the form to run the monitor and send a test email.
+Then open <http://localhost:5000> in a browser, choose a date and keyword, and submit the form to run the monitor and send a test email.

--- a/scripts/manual_server.py
+++ b/scripts/manual_server.py
@@ -1,9 +1,16 @@
 from datetime import datetime
-from flask import Flask, request, jsonify
+from pathlib import Path
+from flask import Flask, request, jsonify, send_file
 
 from tas_parl_monitor import run_monitor
 
 app = Flask(__name__)
+
+
+@app.get("/")
+def index():
+    root = Path(__file__).resolve().parent.parent
+    return send_file(root / "manual_test.html")
 
 @app.post('/run')
 def run():


### PR DESCRIPTION
## Summary
- Serve `manual_test.html` directly from `manual_server` so the form runs on the same origin
- Document visiting `http://localhost:5000` for manual testing

## Testing
- `python -m py_compile scripts/manual_server.py`
- `python - <<'PY'
import sys
sys.path.insert(0, 'scripts')
from manual_server import app
client = app.test_client()
resp_root = client.get('/')
print('root status:', resp_root.status_code, 'length:', len(resp_root.data))
resp_run = client.post('/run', json={})
print('run status:', resp_run.status_code, 'json:', resp_run.get_json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a6b16ae4388332ade74727f8fa4e13