### PR TITLE
Use webdriver-manager to fetch Chrome driver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 selenium>=4.0
 nltk>=3.8
 Flask>=2.0
+webdriver-manager>=4.0

--- a/scripts/tas_parl_monitor.py
+++ b/scripts/tas_parl_monitor.py
@@ -8,9 +8,11 @@ from typing import List, Dict, Optional
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from webdriver_manager.chrome import ChromeDriverManager
 
 import nltk
 
@@ -39,7 +41,8 @@ def make_driver(download_dir: Path):
         "profile.default_content_setting_values.automatic_downloads": 1,
     }
     opts.add_experimental_option("prefs", prefs)
-    return webdriver.Chrome(options=opts)
+    service = Service(ChromeDriverManager().install())
+    return webdriver.Chrome(service=service, options=opts)
 
 
 def wait_downloads_clear(directory: Path):


### PR DESCRIPTION
## Summary
- install webdriver-manager dependency
- use webdriver-manager Service when creating Chrome driver

## Testing
- `python -m py_compile scripts/tas_parl_monitor.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement webdriver-manager>=4.0, 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68a6b500289c833295662ec8aa574b2a