### PR TITLE
Handle hyphenated line breaks in keyword search

### DIFF
--- a/scripts/tas_parl_monitor.py
+++ b/scripts/tas_parl_monitor.py
@@ -196,11 +196,13 @@ def find_speaker(lines: List[str], idx: int) -> str:
 
 def extract_mentions(file_path: Path, keywords: List[str]) -> List[Dict[str, str]]:
     text = file_path.read_text(encoding="utf-8", errors="ignore")
+    # Handle words split by hyphenation across lines.
+    text = re.sub(r"-\s*\n", "", text)
     lines = text.splitlines()
     mentions = []
     for idx, line in enumerate(lines):
         for kw in keywords:
-            if kw.lower() in line.lower():
+            if re.search(rf"\b{re.escape(kw)}\b", line, flags=re.IGNORECASE):
                 start = max(idx - 2, 0)
                 end = min(idx + 3, len(lines))
                 quote = " ".join(l.strip() for l in lines[start:end])


### PR DESCRIPTION
## Summary
- Improve keyword extraction by joining hyphenated line breaks before scanning
- Use regex for case-insensitive whole-word matches

## Testing
- `python -m py_compile scripts/*.py`
- `python - <<'PY'
from pathlib import Path
from scripts.tas_parl_monitor import extract_mentions
print(extract_mentions(Path('transcripts/testcase/test.txt'), ['Premier', 'Budget']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a6d76f001883329b4a315c8e2d08bf